### PR TITLE
Changing the project to use and cache items in a database

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -8,9 +8,9 @@ doctrine:
         #server_version: '5.7'
 
         # Only needed for MySQL (ignored otherwise)
-        charset: utf8mb4
+        charset: utf8
         default_table_options:
-            collate: utf8mb4_unicode_ci
+            collate: utf8_unicode_ci
     orm:
         auto_generate_proxy_classes: true
         naming_strategy: doctrine.orm.naming_strategy.underscore

--- a/src/Command/UpdateGodsCommand.php
+++ b/src/Command/UpdateGodsCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Command;
+
+use App\Service\Smite;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UpdateGodsCommand extends Command
+{
+    protected static $defaultName = 'smite:update-gods';
+
+    /**
+     * @var Smite
+     */
+    protected $smite;
+
+    public function __construct(Smite $smite)
+    {
+        $this->smite = $smite;
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Update the cached Gods');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+
+
+
+        $gods = $this->smite->getGods();
+        foreach ($gods as $god) {
+            echo json_encode($god, JSON_PRETTY_PRINT);
+            return;
+        }
+        // TODO query the local database and check each god
+
+    }
+}

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -27,16 +27,22 @@ class IndexController extends AbstractController
      */
     public function index(): Response
     {
-        $gods = $this->smite->getGodsFormatted();
+        $gods = $this->smite->getGodsByNameKey();
         $gods = array_slice($gods, 1, 12, true);
 
         $duelRankedLeaderboard = $this->smite->getLeagueLeaderboard(440, 27, 6);
         $joustRankedLeaderboard = $this->smite->getLeagueLeaderboard(450, 27, 6);
         $conquestRankedLeaderboard = $this->smite->getLeagueLeaderboard(451, 27, 6);
 
-        $duelRankedLeaderboard = array_slice($duelRankedLeaderboard,  0, 5, true);
-        $joustRankedLeaderboard = array_slice($joustRankedLeaderboard,  0, 5, true);
-        $conquestRankedLeaderboard = array_slice($conquestRankedLeaderboard,  0, 5, true);
+        if (is_array($duelRankedLeaderboard)) {
+            $duelRankedLeaderboard = array_slice($duelRankedLeaderboard, 0, 5, true);
+        }
+        if (is_array($joustRankedLeaderboard)) {
+            $joustRankedLeaderboard = array_slice($joustRankedLeaderboard,  0, 5, true);
+        }
+        if (is_array($conquestRankedLeaderboard)) {
+            $conquestRankedLeaderboard = array_slice($conquestRankedLeaderboard,  0, 5, true);
+        }
 
         $leaderboardTypes = [
             'Conquest' => $conquestRankedLeaderboard,

--- a/src/Entity/GodAbility.php
+++ b/src/Entity/GodAbility.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * GodAbility
  *
- * @ORM\Table(name="god_ability")
+ * @ORM\Table(name="god_ability", uniqueConstraints={@ORM\UniqueConstraint(name="unique_ability_id", columns={"ability_id"})})
  * @ORM\Entity
  */
 class GodAbility

--- a/src/Migrations/Version20191121214333.php
+++ b/src/Migrations/Version20191121214333.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20191121214333 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE clan (id INT UNSIGNED AUTO_INCREMENT NOT NULL, name VARCHAR(255) DEFAULT NULL, date_entered DATETIME DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE god (id INT UNSIGNED AUTO_INCREMENT NOT NULL, smite_id INT DEFAULT NULL, name VARCHAR(255) DEFAULT NULL, attack_speed DOUBLE PRECISION DEFAULT NULL, attack_speed_per_level DOUBLE PRECISION DEFAULT NULL, hp5per_level DOUBLE PRECISION DEFAULT NULL, health DOUBLE PRECISION DEFAULT NULL, health_per_five DOUBLE PRECISION DEFAULT NULL, health_per_level DOUBLE PRECISION DEFAULT NULL, mp5per_level DOUBLE PRECISION DEFAULT NULL, magic_protection DOUBLE PRECISION DEFAULT NULL, magic_protection_per_level DOUBLE PRECISION DEFAULT NULL, magical_power DOUBLE PRECISION DEFAULT NULL, magical_power_per_level DOUBLE PRECISION DEFAULT NULL, mana DOUBLE PRECISION DEFAULT NULL, mana_per_five DOUBLE PRECISION DEFAULT NULL, mana_per_level DOUBLE PRECISION DEFAULT NULL, physical_power DOUBLE PRECISION DEFAULT NULL, physical_power_per_level DOUBLE PRECISION DEFAULT NULL, physical_protection DOUBLE PRECISION DEFAULT NULL, physical_protection_per_level DOUBLE PRECISION DEFAULT NULL, speed DOUBLE PRECISION DEFAULT NULL, pros VARCHAR(255) DEFAULT NULL, cons VARCHAR(255) DEFAULT NULL, on_free_rotation VARCHAR(255) DEFAULT NULL, pantheon VARCHAR(255) DEFAULT NULL, roles VARCHAR(255) DEFAULT NULL, title VARCHAR(255) DEFAULT NULL, type VARCHAR(255) DEFAULT NULL, lore LONGTEXT DEFAULT NULL, card_url VARCHAR(255) DEFAULT NULL, icon_url VARCHAR(255) DEFAULT NULL, date_created DATETIME DEFAULT \'0000-00-00 00:00:00\' NOT NULL, date_updated DATETIME DEFAULT \'0000-00-00 00:00:00\' NOT NULL, UNIQUE INDEX unique_smite_id (smite_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE `match` (id INT UNSIGNED AUTO_INCREMENT NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE god_ability (id INT UNSIGNED AUTO_INCREMENT NOT NULL, god_id INT UNSIGNED DEFAULT NULL, ability_number INT UNSIGNED NOT NULL, ability_id INT UNSIGNED NOT NULL, summary LONGTEXT DEFAULT NULL, url LONGTEXT DEFAULT NULL, cooldown LONGTEXT DEFAULT NULL, cost LONGTEXT DEFAULT NULL, description LONGTEXT DEFAULT NULL, INDEX IDX_17AE6D2A921502AB (god_id), UNIQUE INDEX unique_ability_id (ability_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE api_call (id INT UNSIGNED AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, response_status INT DEFAULT NULL, cached INT NOT NULL, date_created DATETIME DEFAULT \'0000-00-00 00:00:00\' NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE `utf8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE god_ability ADD CONSTRAINT FK_17AE6D2A921502AB FOREIGN KEY (god_id) REFERENCES god (id)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE god_ability DROP FOREIGN KEY FK_17AE6D2A921502AB');
+        $this->addSql('DROP TABLE clan');
+        $this->addSql('DROP TABLE god');
+        $this->addSql('DROP TABLE `match`');
+        $this->addSql('DROP TABLE god_ability');
+        $this->addSql('DROP TABLE api_call');
+    }
+}

--- a/src/Service/Smite.php
+++ b/src/Service/Smite.php
@@ -3,6 +3,7 @@
 namespace App\Service;
 
 use App\Entity\ApiCall;
+use App\Entity\God;
 use Dant89\SmiteApiClient\Client;
 use Dant89\SmiteApiClient\God\GodClient;
 use Dant89\SmiteApiClient\League\LeagueClient;
@@ -153,20 +154,21 @@ class Smite
 
     /**
      * @return array
-     * @throws InvalidArgumentException
      */
-    public function getGodsFormatted(): array
+    public function getGodsByNameKey(): array
     {
-        $gods = $this->getGods();
+        $repository = $this->entityManager->getRepository(God::class);
+        $gods = $repository->findAll();
+
         $formattedGods = [];
 
+        /** @var God $god */
         foreach ($gods as $god) {
-            $formattedGods[$god['Name']] = $god;
+            $formattedGods[$god->getName()] = $god;
         }
 
         return $formattedGods;
     }
-
 
     /**
      * @param string $queue
@@ -316,6 +318,7 @@ class Smite
         $this->logApiCall($cache->getKey(), false, $response->getStatus());
         return $data;
     }
+
     /**
      * @param string $name
      * @return array|null

--- a/templates/god/god.html.twig
+++ b/templates/god/god.html.twig
@@ -1,6 +1,6 @@
 {% extends 'base.html.twig' %}
 
-{% block title %}God {{ god.Name }} - Unofficial SMITE{% endblock %}
+{% block title %}God {{ god.name }} - Unofficial SMITE{% endblock %}
 
 {% block header_meta %}
     <link rel="canonical" href="https://smitestats.com/gods/{{ god.Name|slugify }}" />
@@ -14,96 +14,53 @@
             <div class="row">
 
                 <div class="col-md-4 col-lg-3">
-                    <div class="rounded smite-god" style="background-image: url({{ god.godCard_URL }})">
-                        <a href="{{ path('god_view', {name: god.Name|slugify}) }}" title="Smite God {{ god.Name }}"><h1>{{ god.Name }}</h1></a>
+                    <div class="rounded smite-god" style="background-image: url({{ god.cardUrl }})">
+                        <a href="{{ path('god_view', {name: god.name|slugify}) }}" title="Smite God {{ god.name }}"><h1>{{ god.name }}</h1></a>
                     </div>
                 </div>
 
                 <div class="col-md-4 col-lg-5">
-                    <h4>{{ god.Title }}</h4>
-                    <h4>{{ god.Pantheon }}</h4>
-                    <h4>{{ god.Roles }}</h4>
-                    <h4>{{ god.Type }}</h4>
-                    <h4>{{ god.Pros }}</h4>
-                    <h4>{{ god.Cons }}</h4>
+                    <h4>{{ god.title }}</h4>
+                    <h4>{{ god.pantheon }}</h4>
+                    <h4>{{ god.roles }}</h4>
+                    <h4>{{ god.type }}</h4>
+                    <h4>{{ god.pros }}</h4>
+                    <h4>{{ god.cons }}</h4>
                 </div>
 
                 <div class="col-md-4 col-md-4">
                     <h3>Statistics</h3>
                     <ul>
-                        <li>Attack Speed: {{ god.AttackSpeed }}</li>
-                        <li>Health: {{ god.Health }}</li>
-                        <li>Mana: {{ god.Mana }}</li>
-                        <li>Magic Protection: {{ god.MagicProtection }}</li>
-                        <li>Magical Power: {{ god.MagicalPower }}</li>
-                        <li>Speed: {{ god.Speed }}</li>
+                        <li>Attack Speed: {{ god.attackSpeed }}</li>
+                        <li>Health: {{ god.health }}</li>
+                        <li>Mana: {{ god.mana }}</li>
+                        <li>Magic Protection: {{ god.magicProtection }}</li>
+                        <li>Magical Power: {{ god.magicalPower }}</li>
+                        <li>Speed: {{ god.speed }}</li>
                     </ul>
                 </div>
 
                 <div class="col-12">
 
-                    <p>{{ god.Lore }}</p>
+                    <p>{{ god.lore }}</p>
 
                     <div class="god-abilities">
                         <div class="row">
+                            {% for ability in god.abilities %}
                             <div class="col-12 col-md-4">
                                 <div class="god-ability rounded">
-                                    <img class="float-left mr-2" src="{{ god.Ability_1.URL }}" /><br />
-                                    <h3>{{ god.Ability_1.Summary }}</h3><br />
-                                    <p>{{ god.Ability_1.Description.itemDescription.description }}</p>
+                                    <img class="float-left mr-2" src="{{ ability.url }}" /><br />
+                                    <h3>{{ ability.summary }}</h3><br />
+                                    <p>{{ ability.description }}</p>
                                     <ul>
-                                        <li>Cost: {{ god.Ability_1.Description.itemDescription.cost }}</li>
-                                        <li>Cooldown: {{ god.Ability_1.Description.itemDescription.cooldown }}</li>
+                                        <li>Cost: {{ ability.cost }}</li>
+                                        <li>Cooldown: {{ ability.cooldown }}</li>
                                     </ul>
                                 </div>
                             </div>
-                            <div class="col-12 col-md-4">
-                                <div class="god-ability rounded">
-                                    <img class="float-left mr-2" src="{{ god.Ability_2.URL }}" /><br />
-                                    <h3>{{ god.Ability_2.Summary }}</h3><br />
-                                    <p>{{ god.Ability_2.Description.itemDescription.description }}</p>
-                                    <ul>
-                                        <li>Cost: {{ god.Ability_2.Description.itemDescription.cost }}</li>
-                                        <li>Cooldown: {{ god.Ability_2.Description.itemDescription.cooldown }}</li>
-                                    </ul>
-                                </div>
-                            </div>
-                            <div class="col-12 col-md-4">
-                                <div class="god-ability rounded">
-                                    <img class="float-left mr-2" src="{{ god.Ability_3.URL }}" /><br />
-                                    <h3>{{ god.Ability_3.Summary }}</h3><br />
-                                    <p>{{ god.Ability_3.Description.itemDescription.description }}</p>
-                                    <ul>
-                                        <li>Cost: {{ god.Ability_3.Description.itemDescription.cost }}</li>
-                                        <li>Cooldown: {{ god.Ability_3.Description.itemDescription.cooldown }}</li>
-                                    </ul>
-                                </div>
-                            </div>
-                            <div class="col-12 col-md-4">
-                                <div class="god-ability rounded">
-                                    <img class="float-left mr-2" src="{{ god.Ability_4.URL }}" /><br />
-                                    <h3>{{ god.Ability_4.Summary }}</h3><br />
-                                    <p>{{ god.Ability_4.Description.itemDescription.description }}</p>
-                                    <ul>
-                                        <li>Cost: {{ god.Ability_4.Description.itemDescription.cost }}</li>
-                                        <li>Cooldown: {{ god.Ability_4.Description.itemDescription.cooldown }}</li>
-                                    </ul>
-                                </div>
-                            </div>
-                            <div class="col-12 col-md-4">
-                                <div class="god-ability rounded">
-                                    <img class="float-left mr-2" src="{{ god.Ability_5.URL }}" /><br />
-                                    <h3>{{ god.Ability_5.Summary }}</h3><br />
-                                    <p>{{ god.Ability_5.Description.itemDescription.description }}</p>
-                                    <ul>
-                                        <li>Cost: {{ god.Ability_5.Description.itemDescription.cost }}</li>
-                                        <li>Cooldown: {{ god.Ability_5.Description.itemDescription.cooldown }}</li>
-                                    </ul>
-                                </div>
-                            </div>
+                            {% endfor %}
                         </div>
                     </div>
-
 
                 </div>
 

--- a/templates/god/index.html.twig
+++ b/templates/god/index.html.twig
@@ -19,8 +19,8 @@
                     <div class="row">
                         {% for god in gods %}
                             <div class="col-6 col-sm-4 col-md-3 col-lg-auto">
-                                <div class="rounded smite-god" style="background-image: url({{ god.godCard_URL }})">
-                                    <a href="{{ path('god_view', {name: god.Name|slugify}) }}" title="Smite God {{ god.Name }}">{{ god.Name }}</a>
+                                <div class="rounded smite-god" style="background-image: url({{ god.cardUrl }})">
+                                    <a href="{{ path('god_view', {name: god.name|slugify}) }}" title="Smite God {{ god.name }}">{{ god.name }}</a>
                                 </div>
                             </div>
                         {% endfor %}

--- a/templates/index/index.html.twig
+++ b/templates/index/index.html.twig
@@ -24,8 +24,8 @@
                         <div class="row">
                         {% for god in gods %}
                             <div class="col-6 col-sm-4">
-                                <div class="rounded smite-god" style="background-image: url({{ god.godCard_URL }})">
-                                    <a href="{{ path('god_view', {name: god.Name|slugify}) }}" title="Smite God {{ god.Name }}">{{ god.Name }}</a>
+                                <div class="rounded smite-god" style="background-image: url({{ god.cardUrl }})">
+                                    <a href="{{ path('god_view', {name: god.name|slugify}) }}" title="Smite God {{ god.name }}">{{ god.name }}</a>
                                 </div>
                             </div>
                         {% endfor %}


### PR DESCRIPTION
- Update doctrine default charset options.
- Add a god and ability crawler and storer
- Update index and god index / page to use the gods stored in the database rather than by api calls
- Add database to log all api calls
- Add unique index on god ability ids to prevent duplicates
- Update front-end changes to reflect the use of entities rather than raw arrays